### PR TITLE
feat: add dashboard for number of times an exercise was attempted

### DIFF
--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,6 +1,7 @@
 from app.admin.analytics import EndpointAnalyticsAdmin
 from app.admin.attempt_admin import AttemptAdmin
 from app.admin.endpoint_analytics import AnalyticsDashboard
+from app.admin.exercise_analytics import ExerciseAnalyticsDashboard
 
 from .leaderboard_user_link_admin import LeaderboardUserLinkAdmin
 from .phoneme_admin import PhonemeAdmin
@@ -11,15 +12,19 @@ from .word_of_day_admin import WordOfDayAdmin
 from .word_phoneme_link_admin import WordPhonemeLinkAdmin
 
 
-views = sorted([
-    LeaderboardUserLinkAdmin,
-    PhonemeAdmin,
-    AttemptAdmin,
-    RecordingAdmin,
-    UserAdmin,
-    WordAdmin,
-    WordOfDayAdmin,
-    WordPhonemeLinkAdmin,
-    EndpointAnalyticsAdmin,
-    AnalyticsDashboard,
-], key=lambda x: x.__name__)
+views = sorted(
+    [
+        LeaderboardUserLinkAdmin,
+        PhonemeAdmin,
+        AttemptAdmin,
+        RecordingAdmin,
+        UserAdmin,
+        WordAdmin,
+        WordOfDayAdmin,
+        WordPhonemeLinkAdmin,
+        EndpointAnalyticsAdmin,
+        AnalyticsDashboard,
+        ExerciseAnalyticsDashboard,
+    ],
+    key=lambda x: x.__name__,
+)

--- a/app/admin/auth.py
+++ b/app/admin/auth.py
@@ -19,7 +19,9 @@ class AdminAuth(AuthenticationBackend):
         password = form.get("password")
         if (
             username == self._admin_username
-            and self._password_helper.verify_and_update(password, self._admin_password_hash)[0]
+            and self._password_helper.verify_and_update(password, f"{self._admin_password_hash.strip('’').strip('‘')}")[
+                0
+            ]
         ):
             request.session.update({"authenticated": True})
             return True

--- a/app/admin/auth.py
+++ b/app/admin/auth.py
@@ -19,9 +19,7 @@ class AdminAuth(AuthenticationBackend):
         password = form.get("password")
         if (
             username == self._admin_username
-            and self._password_helper.verify_and_update(password, f"{self._admin_password_hash.strip('’').strip('‘')}")[
-                0
-            ]
+            and self._password_helper.verify_and_update(password, f"{self._admin_password_hash}")[0]
         ):
             request.session.update({"authenticated": True})
             return True

--- a/app/admin/auth.py
+++ b/app/admin/auth.py
@@ -19,7 +19,7 @@ class AdminAuth(AuthenticationBackend):
         password = form.get("password")
         if (
             username == self._admin_username
-            and self._password_helper.verify_and_update(password, f"{self._admin_password_hash}")[0]
+            and self._password_helper.verify_and_update(password, self._admin_password_hash)[0]
         ):
             request.session.update({"authenticated": True})
             return True

--- a/app/admin/endpoint_analytics.py
+++ b/app/admin/endpoint_analytics.py
@@ -13,5 +13,7 @@ class AnalyticsDashboard(BaseView):
     async def analytics(self, request: Request) -> HTMLResponse:
         chart_data: dict = AnalyticsService().get_chart_data()
         return await self.templates.TemplateResponse(
-            request, "admin/analytics.jinja2", context={"chart_data": chart_data}
+            request,
+            "admin/analytics.jinja2",
+            context={"chart_data": chart_data, "chart_title": "API Analytics", "chart_x_label": "Endpoints"},
         )

--- a/app/admin/exercise_analytics.py
+++ b/app/admin/exercise_analytics.py
@@ -11,7 +11,7 @@ class ExerciseAnalyticsDashboard(BaseView):
 
     @expose("/exercise-analytics", methods=["GET"])
     async def exercise_analytics(self, request: Request) -> HTMLResponse:
-        exercise_data: list[dict] = AnalyticsService().get_exercise_analytics()
+        exercise_data: dict = AnalyticsService().get_exercise_analytics()
         return await self.templates.TemplateResponse(
             request,
             "admin/analytics.jinja2",

--- a/app/admin/exercise_analytics.py
+++ b/app/admin/exercise_analytics.py
@@ -1,0 +1,19 @@
+from fastapi import Request
+from fastapi.responses import HTMLResponse
+from sqladmin import BaseView, expose
+
+from app.services.analytics.analytics import AnalyticsService
+
+
+class ExerciseAnalyticsDashboard(BaseView):
+    name = "Exercise Analytics"
+    icon = "fa fa-chart-bar"
+
+    @expose("/exercise-analytics", methods=["GET"])
+    async def exercise_analytics(self, request: Request) -> HTMLResponse:
+        exercise_data: list[dict] = AnalyticsService().get_exercise_analytics()
+        return await self.templates.TemplateResponse(
+            request,
+            "admin/analytics.jinja2",
+            context={"chart_data": exercise_data, "chart_title": "Exercise Analytics", "chart_x_label": "Exercises"},
+        )

--- a/app/admin/templates/admin/analytics.jinja2
+++ b/app/admin/templates/admin/analytics.jinja2
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', function() {
             plugins: {
                 title: {
                     display: true,
-                    text: 'API Endpoint Analytics'
+                    text: {{ chart_title | tojson | safe }}
                 },
                 tooltip: {
                     callbacks: {
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 x: {
                     title: {
                         display: true,
-                        text: 'Endpoints'
+                        text: {{ chart_x_label | tojson | safe }}
                     }
                 },
                 y: {

--- a/app/admin/templates/admin/master.jinja2
+++ b/app/admin/templates/admin/master.jinja2
@@ -37,6 +37,12 @@
                                 </span>
                                 <span class="nav-link-title">API Analytics</span>
                             </a>
+                            <a class="nav-link {% if request.path == '/admin/exercise-analytics' %}active{% endif %}" href="{{ url_for('admin:exercise_analytics') }}">
+                                <span class="nav-link-icon d-md-none d-lg-inline-block">
+                                    <i class="fa fa-chart-bar"></i>
+                                </span>
+                                <span class="nav-link-title">Exercise Analytics</span>
+                            </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" class="nav-item" href="{{ url_for('admin:index') }}">

--- a/app/crud/analytics/analysis_repository.py
+++ b/app/crud/analytics/analysis_repository.py
@@ -22,3 +22,19 @@ class AnalyticsRepository:
         with Session(engine) as session:
             session.add(analytics)
             session.commit()
+
+    def get_exercise_analytics(self) -> Sequence[Tuple[str, int]]:
+        with Session(engine) as session:
+            stmt = (
+                select(
+                    EndpointAnalytics.endpoint,
+                    func.count(EndpointAnalytics.endpoint).label("count"),
+                )
+                .where(EndpointAnalytics.endpoint.contains("exercise"))
+                .where(~EndpointAnalytics.endpoint.contains("admin"))
+                .group_by(EndpointAnalytics.endpoint)
+                .order_by(func.count(EndpointAnalytics.endpoint).desc())
+            )
+
+            result = session.exec(stmt).fetchall()
+            return result

--- a/app/crud/analytics/analysis_repository.py
+++ b/app/crud/analytics/analysis_repository.py
@@ -11,7 +11,7 @@ class AnalyticsRepository:
         with Session(engine) as session:
             stmt = select(
                 EndpointAnalytics.endpoint,
-                func.count().label("count"),
+                func.count(EndpointAnalytics.endpoint).label("count"),  # type: ignore[arg-type]
                 func.avg(EndpointAnalytics.duration).label("avg_response_time"),
             ).group_by(EndpointAnalytics.endpoint)
 
@@ -28,12 +28,12 @@ class AnalyticsRepository:
             stmt = (
                 select(
                     EndpointAnalytics.endpoint,
-                    func.count(EndpointAnalytics.endpoint).label("count"),
+                    func.count(EndpointAnalytics.endpoint).label("count"),  # type: ignore[arg-type]
                 )
-                .where(EndpointAnalytics.endpoint.contains("exercise"))
-                .where(~EndpointAnalytics.endpoint.contains("admin"))
+                .where(EndpointAnalytics.endpoint.contains("exercise"))  # type: ignore[attr-defined]
+                .where(~EndpointAnalytics.endpoint.contains("admin"))  # type: ignore[attr-defined]
                 .group_by(EndpointAnalytics.endpoint)
-                .order_by(func.count(EndpointAnalytics.endpoint).desc())
+                .order_by(func.count(EndpointAnalytics.endpoint).desc())  # type: ignore[arg-type]
             )
 
             result = session.exec(stmt).fetchall()

--- a/app/crud/analytics/analysis_repository.py
+++ b/app/crud/analytics/analysis_repository.py
@@ -1,6 +1,6 @@
 from typing import Any, Sequence, Tuple
 
-from sqlmodel import Session, func, select
+from sqlmodel import Session, col, func, select
 
 from app.database import engine
 from app.models.analytics.analytics import EndpointAnalytics
@@ -11,7 +11,7 @@ class AnalyticsRepository:
         with Session(engine) as session:
             stmt = select(
                 EndpointAnalytics.endpoint,
-                func.count(EndpointAnalytics.endpoint).label("count"),  # type: ignore[arg-type]
+                func.count(col(EndpointAnalytics.endpoint)).label("count"),
                 func.avg(EndpointAnalytics.duration).label("avg_response_time"),
             ).group_by(EndpointAnalytics.endpoint)
 
@@ -28,10 +28,10 @@ class AnalyticsRepository:
             stmt = (
                 select(
                     EndpointAnalytics.endpoint,
-                    func.count(EndpointAnalytics.endpoint).label("count"),  # type: ignore[arg-type]
+                    func.count(col(EndpointAnalytics.endpoint)).label("count"),
                 )
-                .where(EndpointAnalytics.endpoint.contains("exercise"))  # type: ignore[attr-defined]
-                .where(~EndpointAnalytics.endpoint.contains("admin"))  # type: ignore[attr-defined]
+                .where(col(EndpointAnalytics.endpoint).contains("exercise"))
+                .where(~col(EndpointAnalytics.endpoint).contains("admin"))
                 .group_by(EndpointAnalytics.endpoint)
                 .order_by("count")  # type: ignore[arg-type]
             )

--- a/app/crud/analytics/analysis_repository.py
+++ b/app/crud/analytics/analysis_repository.py
@@ -33,7 +33,7 @@ class AnalyticsRepository:
                 .where(EndpointAnalytics.endpoint.contains("exercise"))  # type: ignore[attr-defined]
                 .where(~EndpointAnalytics.endpoint.contains("admin"))  # type: ignore[attr-defined]
                 .group_by(EndpointAnalytics.endpoint)
-                .order_by(func.count(EndpointAnalytics.endpoint).desc())  # type: ignore[arg-type]
+                .order_by("count")  # type: ignore[arg-type]
             )
 
             result = session.exec(stmt).fetchall()

--- a/app/models/analytics/analytics.py
+++ b/app/models/analytics/analytics.py
@@ -1,14 +1,12 @@
 from datetime import datetime
 
-from sqlmodel import Field
-
 from app.models.analytics.http_method import HTTPMethod
 from app.models.id_model import IdModel
 
 
 class EndpointAnalytics(IdModel, table=True):
-    endpoint: str = Field(nullable=False)
-    method: HTTPMethod = Field(nullable=False)
-    status_code: int = Field(nullable=False)
-    duration: float = Field(nullable=False, default=0)
-    timestamp: datetime = Field(default_factory=datetime.now, nullable=False)
+    endpoint: str
+    method: HTTPMethod
+    status_code: int
+    duration: float
+    timestamp: datetime

--- a/app/models/analytics/analytics.py
+++ b/app/models/analytics/analytics.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from sqlmodel import Field
+
 from app.models.analytics.http_method import HTTPMethod
 from app.models.id_model import IdModel
 
@@ -8,5 +10,5 @@ class EndpointAnalytics(IdModel, table=True):
     endpoint: str
     method: HTTPMethod
     status_code: int
-    duration: float
-    timestamp: datetime
+    duration: float = Field(nullable=False, default=0)
+    timestamp: datetime = Field(default_factory=datetime.now, nullable=False)

--- a/app/services/analytics/analytics.py
+++ b/app/services/analytics/analytics.py
@@ -3,7 +3,6 @@ from app.crud.analytics.analysis_repository import AnalyticsRepository
 
 class AnalyticsService:
     def get_chart_data(self) -> dict:
-        
         # Sadly, we can't use the UnitOfWork pattern here, as this service is called from the admin panel
         results = AnalyticsRepository().get_count_of_endpoint_and_response_time()
 
@@ -43,3 +42,27 @@ class AnalyticsService:
             ],
         }
         return chart_data
+
+    def get_exercise_analytics(self) -> dict:
+        results = AnalyticsRepository().get_exercise_analytics()
+
+        # Filter to only get attempts to exercise endpoints
+        results = [r for r in results if r[0].endswith("attempts")]
+
+        results = results = [(x[0].split("/")[-2], x[1]) for x in results]
+
+        endpoints: list[str] = [str(r[0]) for r in results]
+        counts: list[int] = [int(r[1]) for r in results]
+
+        return {
+            "labels": endpoints,
+            "datasets": [
+                {
+                    "label": "# time exercise was attempted",
+                    "data": counts,
+                    "backgroundColor": "rgba(255, 99, 132, 0.5)",
+                    "borderColor": "rgb(255, 99, 132)",
+                    "borderWidth": 1,
+                },
+            ],
+        }


### PR DESCRIPTION
This pull request introduces a new feature for seeing how many times an exercise was attempted in the admin dashboard. It includes changes to various files to integrate this new feature seamlessly.

### New Feature: Exercise Analytics

* [`app/admin/__init__.py`](diffhunk://#diff-a769a128690159ce0bdb709b1daa9b2c5821263de20083d4e24eb390750f2933R4): Added `ExerciseAnalyticsDashboard` to the imports and included it in the `views` list. [[1]](diffhunk://#diff-a769a128690159ce0bdb709b1daa9b2c5821263de20083d4e24eb390750f2933R4) [[2]](diffhunk://#diff-a769a128690159ce0bdb709b1daa9b2c5821263de20083d4e24eb390750f2933L14-R16) [[3]](diffhunk://#diff-a769a128690159ce0bdb709b1daa9b2c5821263de20083d4e24eb390750f2933L25-R30)
* [`app/admin/exercise_analytics.py`](diffhunk://#diff-fe2ac070f3c70f9dea82a41b5676ffe592fbd75923a0b53c906a6461d6ed3c99R1-R19): Created a new `ExerciseAnalyticsDashboard` class to handle exercise analytics, including a new endpoint `/exercise-analytics` that retrieves and displays exercise data.
* [`app/admin/templates/admin/master.jinja2`](diffhunk://#diff-fb2b74c15b373aa9b6b08f9056017afecd43746ec6cb513a312d2546b5992332R40-R45): Added a new navigation link for Exercise Analytics in the admin dashboard.

### Enhancements to Existing Analytics

* [`app/admin/endpoint_analytics.py`](diffhunk://#diff-d5c0c01a0769ceef3cc8b3f88d41eaa14e3a7d975ed8e1917e15a190e7423986L16-R18): Enhanced the `AnalyticsDashboard` to include additional context such as `chart_title` and `chart_x_label` for better chart representation.
* [`app/admin/templates/admin/analytics.jinja2`](diffhunk://#diff-e87c5fc8e5b08236a3e775e329f92c446d7a02dc84af6d622cacc0b1122cb990L44-R44): Updated the template to dynamically display `chart_title` and `chart_x_label` based on the context provided. [[1]](diffhunk://#diff-e87c5fc8e5b08236a3e775e329f92c446d7a02dc84af6d622cacc0b1122cb990L44-R44) [[2]](diffhunk://#diff-e87c5fc8e5b08236a3e775e329f92c446d7a02dc84af6d622cacc0b1122cb990L61-R61)

### Backend Support for Exercise Analytics

* [`app/crud/analytics/analysis_repository.py`](diffhunk://#diff-543c8f8e079cba0608b2045d463e4bbce0323bdc2f6d4759d0789d92785f1c0aR25-R40): Added a new method `get_exercise_analytics` to fetch exercise-related analytics data from the database.
* [`app/services/analytics/analytics.py`](diffhunk://#diff-eee8d8e77dd602af454f69ee4faf19df2267fdd7bc6328c65128980d9fe75f80L6): Implemented `get_exercise_analytics` method in the `AnalyticsService` to process and format the exercise analytics data for the dashboard. [[1]](diffhunk://#diff-eee8d8e77dd602af454f69ee4faf19df2267fdd7bc6328c65128980d9fe75f80L6) [[2]](diffhunk://#diff-eee8d8e77dd602af454f69ee4faf19df2267fdd7bc6328c65128980d9fe75f80R45-R68)